### PR TITLE
Added parametric bootstrap for phylolm 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: phylolm
-Version: 2.4.1
+Version: 2.4.2
 Date: 2016-04-11
 Title: Phylogenetic Linear Regression
 Authors@R: c(person("Lam Si Tung", "Ho", role=c("aut", "cre"), email="lamho86@gmail.com"),

--- a/R/phyloglm.R
+++ b/R/phyloglm.R
@@ -477,8 +477,7 @@ You can increase this bound by increasing 'btol'.")
     # simulate all bootstrap data sets
     bootobject <- rbinTrait(n = boot, phy = phy, beta = results$coefficients,
                             alpha = results$alpha, X = X, model = "LogReg")
-    responsecolumn <- attr(attr(mf, "terms"), "response")
-    
+
     # analyze these bootstrapped data
     ncoeff = length(results$coefficients)
     bootmatrix <- matrix(NA, boot, ncoeff + 1)
@@ -561,10 +560,10 @@ summary.phyloglm <- function(object, ...) {
                p.value = 2*pnorm(-abs(zval)))
   else 
     TAB <- cbind(Estimate = coef(object), StdErr = se, z.value = zval,
-                 p.value = 2*pnorm(-abs(zval)), 
-#                  bootMean = object$bootmean[1:object$d], bootStdErr = object$bootsd[1:object$d],
                  lowerbootCI = object$bootconfint95[1,1:object$d], 
-                 upperbootCI = object$bootconfint95[2,1:object$d])
+                 upperbootCI = object$bootconfint95[2,1:object$d],
+                 p.value = 2*pnorm(-abs(zval)))
+
   if (object$method %in% c("logistic_MPLE","logistic_IG10")) {
     res <- list(call=object$call,
                 coefficients=TAB,

--- a/R/phylolm.R
+++ b/R/phylolm.R
@@ -1,7 +1,9 @@
 phylolm <- function(formula, data=list(), phy, 
 	model=c("BM","OUrandomRoot","OUfixedRoot","lambda","kappa","delta","EB","trend"),
-	lower.bound=NULL, upper.bound=NULL, starting.value=NULL, measurement_error = FALSE, ...) 
+	lower.bound=NULL, upper.bound=NULL, starting.value=NULL, measurement_error = FALSE,
+	boot=0,full.matrix = TRUE, ...)
 {
+
   ## initialize	
   if (!inherits(phy, "phylo")) stop("object \"phy\" is not of class \"phylo\".")
   model = match.arg(model)	
@@ -68,12 +70,12 @@ phylolm <- function(formula, data=list(), phy,
 
   ## Default bounds
   bounds.default = matrix(c(1e-7/Tmax,50/Tmax,1e-7,1,1e-6,1,1e-5,3,-3/Tmax,0,1e-16,1e16), ncol=2, byrow=TRUE)
-  rownames(bounds.default) = c("alpha","lambda","kappa","delta","rate","err_sigma2")
+  rownames(bounds.default) = c("alpha","lambda","kappa","delta","rate","sigma2_error")
   colnames(bounds.default) = c("min","max")
 
   ## Default starting values
   starting.values.default = c(0.5/Tmax,0.5,0.5,0.5,-1/Tmax,1) 
-  names(starting.values.default) = c("alpha","lambda","kappa","delta","rate","err_sigma2")
+  names(starting.values.default) = c("alpha","lambda","kappa","delta","rate","sigma2_error")
 
   ## User defined bounds and starting values
   if (is.null(lower.bound)) {
@@ -99,12 +101,14 @@ phylolm <- function(formula, data=list(), phy,
     if (model=="kappa") starting.value = starting.values.default[3]
     if (model=="delta") starting.value = starting.values.default[4]
     if (model=="EB") starting.value = starting.values.default[5]
-  }	
+  }
+
   if (measurement_error) {
     lower.bound = c(lower.bound, bounds.default[6,1])
     upper.bound = c(upper.bound, bounds.default[6,2])
     starting.value = c(starting.value, starting.values.default[6])
   }
+
 
   ## preparing for general use of "parameter" for branch length transformation
   prm = list(myname = starting.value[1])
@@ -112,11 +116,11 @@ phylolm <- function(formula, data=list(), phy,
   if (model %in% OU) names(prm) = "alpha"
   if (model == "EB") names(prm) = "rate"
   if (measurement_error) {
-    if (model %in% c("BM","trend")) names(prm) = "err_sigma2"
-    else prm[["err_sigma2"]] = starting.value[2]
+    if (model %in% c("BM","trend")) names(prm) = "sigma2_error"
+    else prm[["sigma2_error"]] = starting.value[2]
   }
-	
-  ## log-likelihood, computation using the three-point stucture
+
+  ## log-likelihood, computation using the three-point structure
   ole= 4 + 2*d + d*d # output length
   loglik <- function(parameters,y,X) {
     tree = transf.branch.lengths(phy,model,parameters=parameters,
@@ -158,73 +162,119 @@ phylolm <- function(formula, data=list(), phy,
 
   if ((model %in% c("BM","trend"))&&(!measurement_error)) {
     BMest = loglik(prm, y, X) # root edge taken to be 0
-    results <- list(coefficients=BMest$betahat, sigma2=BMest$sigma2hat, optpar=NULL, err_sigma2 = 0,
+    results <- list(coefficients=BMest$betahat, sigma2=BMest$sigma2hat, optpar=NULL, sigma2_error = 0,
                     logLik=-BMest$n2llh/2, p=1+d, aic=2*(1+d)+BMest$n2llh, vcov = BMest$vcov)
   } else {
-    ## Optimization of phylogenetic correlation parameter is needed
-    if (sum(lower>start)+sum(upper<start)>0)
+    ##------- Optimization of phylogenetic correlation parameter is needed ---------#
+    # firts: checks of bounds
+    if (sum(lower>start)+sum(upper<start)>0 )
       stop("The starting value is not within the bounds of the parameter.")
-    
+
+    # def of function to be optimized
+    # minus2llh_sinvar: return the -loglik given a single variable: measure-err
+    #    logvalue=log of measure-err variance
+    #    if not BM: prm[[1]] needs up-to-date before calling this fcn:
+    #               prm[[1]] = alpha or lamda or kappa or rate
+    minus2llh_sinvar=function(logvalue) {
+      if(model %in% c("BM","trend")){
+        prm[[1]] = exp(logvalue)
+      } else
+        prm[[2]] = exp(logvalue)
+      loglik(prm, y, X)$n2llh
+    }
+    # minus2llh: returns -loglik given 'alpha' and possibly measurement error
     minus2llh <- function(logvalue) {
       if (model == "EB") prm[[1]]=logvalue[1] # which is 'rate', not log(rate)
       else prm[[1]]=exp(logvalue[1]) # first element is the parameter of the model
-      if ((measurement_error)&&(!(model %in% c("BM","trend")))) prm[[2]]=exp(logvalue[2])
+      if ((measurement_error)&&(!(model %in% c("BM","trend")))){
+        prm[[2]]=exp(logvalue[2])
+      }
       loglik(prm, y, X)$n2llh
     }
-    
-    if (lower[1]==upper[1]) {
-      MLEvalue = lower
-    } else {
-      if (model == "EB") {
-        logstart = start
-        loglower = lower
-        logupper = upper 
-      } else {
+
+    # get objects to start the search, and to bound the search
+    if (lower[1]==upper[1] && !(measurement_error)) { # no optimization in fact
+      prm[[1]] = lower[1]
+      BMest = loglik(prm, y, X)
+    }  else {
+      if(model !="EB"){   # logstart = (log(alpha/lambda...), log(m.e. variance)) or just log(alpha,...)
         logstart = log(start)
         loglower = log(lower)
         logupper = log(upper)
+      } else{
+        # logstart = (rate, log(m.e. variance)) or just rate
+        logstart = start  # do *not* log transform 'rate' because it is <= 0
+        loglower = lower
+        logupper = upper
+        if(measurement_error){
+          logstart[2] = log(start[2])
+          loglower[2] = log(lower[2])
+          logupper[2] = log(upper[2])
+        }
       }
-      opt <- optim(logstart, fn = minus2llh,
-                   method = "L-BFGS-B",lower=loglower, upper = logupper, ...)
-      if (model == "EB") MLEvalue = as.numeric(opt$par[1]) else MLEvalue = as.numeric(exp(opt$par[1]))
-      if ((measurement_error)&&(!(model %in% c("BM","trend")))) MLEerr_sigma2 = as.numeric(exp(opt$par[2]))
+      if (!(model %in% c("BM","trend")) && lower[1] != upper[1]){
+        opt <- optim(logstart, fn = minus2llh, method = "L-BFGS-B",lower=loglower, upper = logupper, ...)
+        # next: get (co)variance parameters alpha/lambda... and m.e. variance into "prm"
+        #       to be used later in loglik to get the estimated beta and sigma2.
+        if (model == "EB") MLEvalue = as.numeric(opt$par[1]) else MLEvalue = as.numeric(exp(opt$par[1]))
+        prm[[1]] = MLEvalue
+        if ((isTRUE(all.equal(MLEvalue,lower[1], tol=tol)))||(isTRUE(all.equal(MLEvalue,upper[1],tol=tol)))) {
+          matchbound = 1
+          if ((model %in% c("lambda","kappa"))&&(MLEvalue == 1)) matchbound=0
+          if ((model == "EB")&&(MLEvalue == 0)) matchbound=0
+          if (matchbound)
+            warning(paste("the estimation of", names(prm)[1],
+                          'matches the upper/lower bound for this parameter.
+                          You may change the bounds using options "upper.bound" and "lower.bound".\n'))
+        }
+        if (measurement_error){
+            MLEsigma2_error = as.numeric(exp(opt$par[2]))
+            prm[[2]] = MLEsigma2_error
+        }
+      } else { # then there must be measurement error
+          # if BM or trend, logstart = log(m.e. variance), already set above.
+          if (!(model %in% c("BM","trend"))) { # then we must have (lower[1]==upper[1])
+            prm[[1]]=lower[1]
+            logstart=logstart[2]
+            loglower=loglower[2]
+            logupper=logupper[2]
+          }
+          opt <- optim(logstart, fn = minus2llh_sinvar,method = "L-BFGS-B",lower=loglower, upper = logupper, ...)
+          MLEsigma2_error = as.numeric(exp(opt$par[1]))
+          if (model %in% c("BM","trend")){
+            prm[[1]] = MLEsigma2_error
+          } else {
+            prm[[2]] = MLEsigma2_error
+          }
+      }
+      # estimate beta and sigma2:
+      BMest = loglik(prm, y, X)
     }
-    if ((isTRUE(all.equal(MLEvalue,lower, tol=tol)))||(isTRUE(all.equal(MLEvalue,upper,tol=tol)))) {
-      matchbound = 1
-      if ((model %in% c("lambda","kappa"))&&(MLEvalue == 1)) matchbound=0
-      if ((model == "EB")&&(MLEvalue == 0)) matchbound=0
-      if (matchbound)
-        warning(paste("the estimation of", names(prm), 'matches the upper/lower bound for this parameter.
- You may change the bounds using options "upper.bound" and "lower.bound".\n'))
-    }
-    prm[[1]] = MLEvalue
-    err_sigma2hat = 0
-    if ((measurement_error)&&(!(model %in% c("BM","trend")))) prm[[2]] = MLEerr_sigma2
-    BMest = loglik(prm, y, X)
-    if (measurement_error) {
-      if (model %in% c("BM","trend")) err_sigma2hat = MLEvalue*BMest$sigma2hat
-      else err_sigma2hat = MLEerr_sigma2*BMest$sigma2hat
-    }
+    # rescaling measurement error by sigma2
+    sigma2_errorhat = 0
+    if (measurement_error)
+     sigma2_errorhat = MLEsigma2_error * BMest$sigma2hat
+    # rescale sigma2 if OU, because it was "gamma" originally: sigma2 = 2 alpha gamma:
     if (model %in% OU)
-      BMest$sigma2hat = 2*MLEvalue * BMest$sigma2hat # was "gamma" originally: sigma2 = 2 alpha gamma
-    results <- list(coefficients=BMest$betahat, sigma2=BMest$sigma2hat, optpar=MLEvalue, err_sigma2 = err_sigma2hat,
+      BMest$sigma2hat = 2*prm[[1]] * BMest$sigma2hat
+      results <- list(coefficients=BMest$betahat, sigma2=BMest$sigma2hat, optpar=prm[[1]], sigma2_error = sigma2_errorhat,
                     logLik=-BMest$n2llh/2, p=2+d, aic=2*(2+d)+BMest$n2llh, vcov = BMest$vcov)
     if (model %in% c("BM","trend")) { # adjust for BM and trend models
       results$optpar = NULL
       results$p = results$p - 1
       results$aic = results$aic - 2
     }
-  }
-  
-  if (measurement_error) {
-    results$p = results$p + 1 # adjust the number of parameters
-    results$aic = results$aic + 2 # adjust AIC value
-  }
+    if (measurement_error) {
+      results$p = results$p + 1 # adjust the number of parameters
+      results$aic = results$aic + 2 # adjust AIC value
+    }
+  } # end of cases that are not BM only
 
   names(results$coefficients) = colnames(X)
   colnames(results$vcov) = colnames(X)
   rownames(results$vcov) = colnames(X)
-  results$fitted.values = X %*% results$coefficients
+  results$fitted.values = drop(X %*% results$coefficients)
+  # drop: simplifies to vector, instead of matrix with 1 column
   results$residuals = y - results$fitted.values
   results$mean.tip.height = Tmax
   results$y = y
@@ -234,6 +284,124 @@ phylolm <- function(formula, data=list(), phy,
   results$formula = formula
   results$call = match.call()
   results$model = model
+  results$boot = boot
+
+
+  if (boot>0) {
+  # Turn off warnings
+    options(warn=-1)
+    # simulate all bootstrap data sets
+    simmodel=model
+    OU = c("OUrandomRoot","OUfixedRoot")
+    if (model %in% OU){
+      simmodel="OU"
+    }
+    # prm has "alpha" and "sigma2_error". Here we want "alpha" and "sigma2"
+    prmsimul = list(sigma2 = results$sigma2)
+    if (!(simmodel %in% c("BM","trend"))){
+      Noname=prm[[1]]
+      names(Noname)=NULL
+      prmsimul[[2]] = Noname
+      names(prmsimul)[2] = names(prm)[1]
+    }
+
+    # booty = bootstrap y response. parameter list depends on the model
+    booty <- results$fitted.values +
+     rTrait(n = boot, phy = phy,model = simmodel, parameters=prmsimul)
+     # by default: ancestral.state=0 and optimal.value=0 --used for OU model only
+    if (measurement_error){
+      booty <- booty + rnorm(boot*n, mean=0, sd=sqrt(results$sigma2_error))
+    }
+
+    # analyze these bootstrapped data
+    ncoeff = length(results$coefficients)
+    colnumberalpha=ncoeff+2
+    # nparam_var: number of parameters that affect the variances and covariances
+    nparam_var = 1 # for sigma2
+    if (measurement_error){
+        nparam_var = nparam_var+1
+        colnumberalpha=colnumberalpha+1
+    }
+    if (!(model %in% c("BM","trend"))) { nparam_var=nparam_var+1}
+    # initialize bootmatrix: matrix with bootstrap estimated parameters
+    bootmatrix <- matrix(NA, boot, ncoeff + nparam_var)
+    colnames(bootmatrix) <- paste0("v",1:(ncoeff + nparam_var)) # temporary names, to initialize
+    colnames(bootmatrix)[1:ncoeff] <- names(results$coefficients)
+    colnames(bootmatrix)[ncoeff+1] <- "sigma2"
+    if (measurement_error){
+      colnames(bootmatrix)[ncoeff+2] <- "sigma2_error"
+    }
+    if (!(model %in% c("BM","trend"))) {
+      colnames(bootmatrix)[colnumberalpha] <- names(prm)[1]
+    }
+    cat("starting of the bootstrap data\n")
+    for (i in 1:boot){
+      y = booty[,i]
+      # all other cases: first get 'prm' up-to-date.
+      if (!(model %in% c("BM","trend")) && lower[1]==upper[1])
+        bootmatrix[i,colnumberalpha] = lower[1] # will be used later to update 'prm'
+
+      # otherwise: something needs to be optimized: m.e., alpha, or both.
+      # below: storing 'standardized' estimated of m.e. variance in MLEsigma2_error. Rescaled later.
+      if (!(model %in% c("BM","trend")) && lower[1] != upper[1]){
+        opt <- optim(logstart, fn = minus2llh, method = "L-BFGS-B",lower=loglower, upper = logupper, ...)
+        if (model == "EB") {
+          bootmatrix[i,colnumberalpha] = as.numeric(opt$par[1]); # will be used later to update 'prm'
+        } else {
+          bootmatrix[i,colnumberalpha] = as.numeric(exp(opt$par[1]));
+        }
+        if(measurement_error)  MLEsigma2_error = as.numeric(exp(opt$par[2]))
+      } else {
+        if(measurement_error){
+          opt <- optim(logstart, fn = minus2llh_sinvar,method = "L-BFGS-B",lower=loglower, upper = logupper, ...)
+          MLEsigma2_error = as.numeric(exp(opt$par[1]))
+        }
+      }
+
+      if (!(model %in% c("BM","trend")))
+        prm[[1]] = bootmatrix[i,colnumberalpha] # update of 'prm'
+      if (measurement_error){
+        if (!(model %in% c("BM","trend"))) {
+          prm[[2]] = MLEsigma2_error
+        } else {
+          prm[[1]] = MLEsigma2_error
+        }
+      }
+      BMest = loglik(prm, y, X)
+      if (model %in% OU)
+             BMest$sigma2hat = 2*prm[[1]] * BMest$sigma2hat # was "gamma" originally: sigma2 = 2 alpha gamma
+      if (measurement_error)
+             bootmatrix[i,ncoeff+2] <- MLEsigma2_error * BMest$sigma2hat
+            bootmatrix[i,1:ncoeff] <- BMest$betahat
+            bootmatrix[i,ncoeff+1] <- BMest$sigma2hat
+    } # end of loop over bootstrap reps
+    # summarize bootstrap estimates
+    ind.na <- which(is.na(bootmatrix[,1]))
+    # indices of replicates that failed: phyloglm had an error
+    if (length(ind.na)>0) {
+      bootmatrix <- bootmatrix[-ind.na,]
+      numOnes <- range(apply(booty[,ind.na],2,sum))
+    }
+    bootmean <- apply(bootmatrix, 2, mean)
+    bootsd <- apply(bootmatrix, 2, sd)
+    bootconfint95 <- apply(bootmatrix, 2, quantile, probs = c(.025, .975))
+    bootmeansdLog = matrix(NA,2,nparam_var) # will give NaN for rate, but won't be printed.
+    colnames(bootmeansdLog) = colnames(bootmatrix)[(ncoeff+1):(ncoeff+nparam_var)]
+    for (i in 1:nparam_var){
+      bootmeansdLog[1,i] <- mean(log(bootmatrix[, ncoeff + i]))
+      bootmeansdLog[2,i] <- sd(log(bootmatrix[, ncoeff + i]))
+    }
+
+    results$bootmean = bootmean
+    results$bootsd = bootsd
+    results$bootconfint95 = bootconfint95
+    results$bootmeansdLog = bootmeansdLog
+    results$bootnumFailed = length(ind.na)
+    if (full.matrix) results$bootstrap = bootmatrix
+
+    ### Turn on warnings
+    options(warn=0)
+  }
   class(results) = "phylolm"
   return(results)
 }
@@ -256,7 +424,7 @@ print.phylolm <- function(x, digits = max(3, getOption("digits") - 3), ...){
     cat("\n")
   }
   cat("sigma2:",x$sigma2,"\n")
-  if (x$err_sigma2 > 0) cat("err_sigma2:",x$err_sigma2,"\n")
+  if (x$sigma2_error > 0) cat("sigma2_error:",x$sigma2_error,"\n")
   cat("\nCoefficients:\n")
   print(x$coefficients)
 }
@@ -264,13 +432,28 @@ print.phylolm <- function(x, digits = max(3, getOption("digits") - 3), ...){
 summary.phylolm <- function(object, ...) {
   se <- sqrt(diag(object$vcov))
   tval <- coef(object) / se
-  TAB <- cbind(Estimate = coef(object), StdErr = se, t.value = tval,
-               p.value = 2*pt(-abs(tval), df=object$n - object$d))
+
+  if (object$boot == 0)
+    TAB <- cbind(Estimate = coef(object), StdErr = se, t.value = tval,
+                 p.value = 2*pt(-abs(tval), df=object$n - object$d))
+  else
+    TAB <- cbind(Estimate = coef(object), StdErr = se, t.value = tval,
+                 lowerbootCI = object$bootconfint95[1,1:object$d],
+                 upperbootCI = object$bootconfint95[2,1:object$d],
+                 p.value = 2*pt(-abs(tval), df=object$n - object$d)) # need p-value last for printCoefmat
+
   res <- list(call=object$call, coefficients=TAB,
               residuals = object$residuals, sigma2 = object$sigma2,
-              optpar=object$optpar, err_sigma2 = object$err_sigma2, logLik=object$logLik,
+              optpar=object$optpar, sigma2_error = object$sigma2_error, logLik=object$logLik,
               df=object$p, aic=object$aic, model=object$model,
-              mean.tip.height=object$mean.tip.height)
+              mean.tip.height=object$mean.tip.height,
+              bootNrep = ifelse(object$boot>0, object$boot - object$bootnumFailed, 0))
+  if (res$bootNrep>0) {
+    res$bootmean = object$bootmean
+    res$bootsd = object$bootsd
+    res$bootconfint95 = object$bootconfint95
+    res$bootmeansdLog <- object$bootmeansdLog
+  }
   class(res) = "summary.phylolm"
   res
 }
@@ -286,7 +469,7 @@ print.summary.phylolm <- function(x, digits = max(3, getOption("digits") - 3), .
   names(r) <- c("Min", "1Q", "Median", "3Q", "Max")
   cat("\nRaw residuals:\n")
   print(r, digits = digits)
-  
+
   cat("\nMean tip height:",x$mean.tip.height)
   cat("\nParameter estimate(s) using ML:\n")
   if (!is.null(x$optpar)) {
@@ -295,8 +478,10 @@ print.summary.phylolm <- function(x, digits = max(3, getOption("digits") - 3), .
     if (x$model=="EB") cat("rate:",x$optpar)
     cat("\n")
   }
+
   cat("sigma2:",x$sigma2,"\n")
-  if (x$err_sigma2 > 0) cat("err_sigma2:",x$err_sigma2,"\n")
+  if (x$sigma2_error > 0) cat("sigma2_error:",x$sigma2_error,"\n")
+
   cat("\nCoefficients:\n")
   printCoefmat(x$coefficients, P.values=TRUE, has.Pvalue=TRUE)
   if (!is.null(x$optpar)) {
@@ -304,8 +489,26 @@ print.summary.phylolm <- function(x, digits = max(3, getOption("digits") - 3), .
     if (x$model %in% c("OUrandomRoot","OUfixedRoot")) cat("alpha=",x$optpar,".",sep="")
     if (x$model %in% c("lambda","kappa","delta")) cat(x$model,"=",x$optpar,".",sep="")
     if (x$model=="EB") cat("rate=",x$optpar,".",sep="")
+    cat("\n")
   }
-  cat("\n")
+
+  if (x$bootNrep > 0) {
+    cat("\n")
+    ncoef = nrow(x$coefficients)
+    nparam_var=length(x$bootmean)-ncoef # number of variance/covariance parameters
+
+    for (i in 1:nparam_var){
+      tmp = colnames(x$bootmeansdLog)[i]# sigma2, sigma2_error or lambda/alpha/...
+      tmp = ifelse(tmp %in% c("sigma2", "sigma2_error"), tmp, "optpar")
+      cat(colnames(x$bootmeansdLog)[i],": ",x[[tmp]],"\n", sep="")
+      cat("      bootstrap mean: ",    x$bootmean[ncoef+i]   ," (on raw scale)","\n",sep="")
+      if (!(x$model %in% c("EB","lambda")) || tmp != "optpar"){
+        cat("                      ",exp(x$bootmeansdLog[1,i])," (on log scale, then back transformed)","\n",sep="")
+        cat("      bootstrap 95% CI: (",x$bootconfint95[1,ncoef+i],",",x$bootconfint95[2,ncoef+i],")\n\n", sep="")
+      }
+    }
+    cat("Parametric bootstrap results based on",x$bootNrep,"fitted replicates\n")
+  }
 }
 ################################################
 residuals.phylolm <-function(object,type=c("response"), ...){

--- a/R/tools.R
+++ b/R/tools.R
@@ -57,7 +57,7 @@ transf.branch.lengths <-
 
   ## Default parameters
   parameters.default = c(0,1,1,1,0,0)
-  names(parameters.default) = c("alpha", "lambda", "kappa", "delta", "rate", "err_sigma2")
+  names(parameters.default) = c("alpha", "lambda", "kappa", "delta", "rate", "sigma2_error")
 
   ## User defined parameters
   if (is.null(parameters)) {
@@ -71,14 +71,14 @@ transf.branch.lengths <-
                       is.null(parameters$kappa),
                       is.null(parameters$delta),
                       is.null(parameters$rate),
-                      is.null(parameters$err_sigma2))
+                      is.null(parameters$sigma2_error))
       parameters.user <- c(parameters$alpha,
                            parameters$lambda,
                            parameters$kappa,
                            parameters$delta,
                            parameters$rate,
-                           parameters$err_sigma2)
-      names(parameters.default) = c("alpha", "lambda", "kappa", "delta", "rate", "err_sigma2")
+                           parameters$sigma2_error)
+      names(parameters.default) = c("alpha", "lambda", "kappa", "delta", "rate", "sigma2_error")
       parameters <- parameters.default
       parameters[specified] <- parameters.user 
     }				
@@ -88,11 +88,11 @@ transf.branch.lengths <-
     kappa = parameters[3],
     delta = parameters[4],
     rate = parameters[5],
-    err_sigma2 = parameters[6]) # note that err_sigma2 = true_err_sigma2/sigma2
+    sigma2_error = parameters[6]) # note that sigma2_error = true_sigma2_error/sigma2
 
   root.edge = 0 # default, holds for most models. Assumes original tree has no root edge.
   diagWeight = rep(1,n)
-  errEdge = rep(p$err_sigma2,n)
+  errEdge = rep(p$sigma2_error,n)
 
   ## BM model
   if (model %in% c("BM","trend")) {

--- a/README.md
+++ b/README.md
@@ -32,5 +32,6 @@ devtools::install_github("lamho86/phylolm")
 - OU shift detection
 - continuous and discrete trait simulators with covariates
 - bootstrap-based confidence intervals for phylogenetic logistic regression (from v2.3)
+  and phylogenetic regression (from v2.4.2)
 - goodness-of-fit test of a population tree with the coalescent (from v.2.4)
 - allowing measurement errors in phylogenetic linear regression (from v2.4.1)

--- a/man/phylolm-package.Rd
+++ b/man/phylolm-package.Rd
@@ -9,7 +9,7 @@ Other tools include functions to test the adequacy of a population tree.}
 \tabular{ll}{
 Package: \tab phylolm\cr
 Type: \tab Package\cr
-Version: \tab 2.4.1\cr
+Version: \tab 2.4.2\cr
 Date: \tab 2016-04-11\cr
 License: \tab GPL (>= 2)\cr
 }

--- a/man/phylolm.Rd
+++ b/man/phylolm.Rd
@@ -7,8 +7,9 @@
 \usage{
 phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
        "OUfixedRoot", "lambda", "kappa", "delta", "EB", "trend"),
-       lower.bound = NULL, upper.bound = NULL, boot=0,
-       starting.value = NULL, measurement_error = FALSE, ...)
+       lower.bound = NULL, upper.bound = NULL,
+       starting.value = NULL, measurement_error = FALSE,
+       boot=0,full.matrix = TRUE ...)
 }
 
 \arguments{
@@ -19,9 +20,10 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
   \item{model}{a model for the covariance (see Details).}
   \item{lower.bound}{optional lower bound for the optimization of the phylogenetic model parameter.}
   \item{upper.bound}{optional upper bound for the optimization of the phylogenetic model parameter.}
-  \item{boot}{number of independent bootstrap replicates, 0 means no bootstrap.}
   \item{starting.value}{optional starting value for the optimization of the phylogenetic model parameter.}
-  \item{measurement_error}{a logical value indicating whether there is measurement errors \code{error_sigma2}.}
+  \item{measurement_error}{a logical value indicating whether there is measurement error \code{sigma2_error} (see Details).}
+  \item{boot}{number of independent bootstrap replicates, 0 means no bootstrap.}
+  \item{full.matrix}{if \code{TRUE}, the full matrix of bootstrap estimates (coefficients and covariance parameters) will be returned.}
   \item{\dots}{further arguments to be passed to the function \code{optim}.}
 }
 \details{This function uses an algorithm that is linear in the number of
@@ -36,13 +38,20 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
   model (\code{EB}), and the Brownian motion model with a trend
   (\code{trend}).
 
+  Using measurement error means that the covariance matrix is taken
+  to be \eqn{\sigma^2*V + \sigma^2_{error}*I}{sigma^2 * V + sigma^2_error * I}
+  where \eqn{V} is the phylogenetic covariance matrix from the chosen model,
+  \eqn{I} is the identity matrix, and \eqn{\sigma^2_{error}}{sigma^2_error} is the
+  variance of the measurement error (which could include environmental variability,
+  sampling error on the species mean, etc.).
+
   By default, the bounds on the phylogenetic parameters are
   \eqn{[10^{-7}/T,50/T]} for \eqn{\alpha}{alpha}, 
   \eqn{[10^{-7},1]} for \eqn{\lambda}{lambda},
   \eqn{[10^{-6},1]} for \eqn{\kappa}{kappa},
   \eqn{[10^{-5},3]} for \eqn{\delta}{delta} and
   \eqn{[-3/T,0]} for \code{rate}, where \eqn{T} is the mean root-to-tip distance.
-  \eqn{[10^{-16}, 10^{16}]} for ratio \code{error_sigma2}/\code{sigma2} (if measurement errors exist).
+  \eqn{[10^{-16}, 10^{16}]} for the ratio \code{sigma2_error}/\code{sigma2} (if measurement errors is used).
 }
 \value{
    \item{coefficients}{the named vector of coefficients.}
@@ -113,6 +122,10 @@ The trend model can only be used with non-ultrametric trees. For this
 model, one predictor variable is added to the model whose values are the
 distances from the root to every tip of the tree. The estimate of the
 coefficent for this variable forms the trend value.
+
+Pagel's \eqn{\lambda}{lambda} model and measurement error cannot be used together:
+the parameters \eqn{\lambda}{lambda}, \eqn{\sigma^2}{sigma^2} and
+\eqn{\sigma^2_{error}}{sigma^2_error} are not distinguishable (identifiable) from each other.
 }
 \seealso{
 \code{\link[ape]{corBrownian}}, \code{\link[ape]{corMartins}},
@@ -136,7 +149,7 @@ summary(fit)
 # adding measurement errors and bootstrap
 z <- y + rnorm(60,0,1)
 dat = data.frame(trait=z[taxa],pred=x[taxa])
-fit = phylolm(trait~pred,data=dat,phy=tre,model="lambda",measurement_error=TRUE,boot=100)
+fit = phylolm(trait~pred,data=dat,phy=tre,model="BM",measurement_error=TRUE,boot=100)
 summary(fit)
 
 }

--- a/man/phylolm.Rd
+++ b/man/phylolm.Rd
@@ -7,7 +7,7 @@
 \usage{
 phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
        "OUfixedRoot", "lambda", "kappa", "delta", "EB", "trend"),
-       lower.bound = NULL, upper.bound = NULL, 
+       lower.bound = NULL, upper.bound = NULL, boot=0,
        starting.value = NULL, measurement_error = FALSE, ...)
 }
 
@@ -19,6 +19,7 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
   \item{model}{a model for the covariance (see Details).}
   \item{lower.bound}{optional lower bound for the optimization of the phylogenetic model parameter.}
   \item{upper.bound}{optional upper bound for the optimization of the phylogenetic model parameter.}
+  \item{boot}{number of independent bootstrap replicates, 0 means no bootstrap.}
   \item{starting.value}{optional starting value for the optimization of the phylogenetic model parameter.}
   \item{measurement_error}{a logical value indicating whether there is measurement errors \code{error_sigma2}.}
   \item{\dots}{further arguments to be passed to the function \code{optim}.}
@@ -46,7 +47,7 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
 \value{
    \item{coefficients}{the named vector of coefficients.}
    \item{sigma2}{the maximum likelihood estimate of the variance rate \eqn{\sigma^2}{sigma^2}.}
-   \item{err_sigma2}{the maximum likelihood estimate of the variance of the measurement errors.}
+   \item{sigma2_error}{the maximum likelihood estimate of the variance of the measurement errors.}
    \item{optpar}{the optimized value of the phylogenetic correlation parameter (alpha, lambda, kappa, delta or rate).}
    \item{logLik}{the maximum of the log likelihood.}
    \item{p}{the number of all parameters of the model.}
@@ -64,6 +65,13 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
    \item{formula}{the model formula}
    \item{call}{the original call to the function}
    \item{model}{the phylogenetic model for the covariance}
+   \item{bootmean}{(\code{boot > 0} only) bootstrap means of the parameters estimated.}
+  \item{bootsd}{(\code{boot > 0} only) bootstrap standard deviations of the estimated parameters.}
+  \item{bootconfint95}{(\code{boot > 0} only) bootstrap 95\% confidence interval.}
+  \item{bootmeansdLog}{(\code{boot > 0} only) bootstrap mean and standard deviation of the logs of the estimated covariance parameters.}
+  \item{bootnumFailed}{(\code{boot > 0} only) number of independent bootstrap replicates for which
+  \code{phylolm} failed. These failures may be due to the bootstrap data having too few 0's or too few 1's.}
+  \item{bootstrap}{(\code{boot > 0} and \code{full.matrix} = \code{TRUE} only) matrix of all bootstrap estimates.}
 }
 \references{
 Ho, L. S. T. and Ane, C. 2014.  "A linear-time algorithm for Gaussian and non-Gaussian trait evolution models". Systematic Biology \bold{63}(3):397-408.
@@ -125,10 +133,10 @@ dat = data.frame(trait=y[taxa],pred=x[taxa])
 fit = phylolm(trait~pred,data=dat,phy=tre,model="lambda")
 summary(fit)
 
-# adding measurement errors
+# adding measurement errors and bootstrap
 z <- y + rnorm(60,0,1)
 dat = data.frame(trait=z[taxa],pred=x[taxa])
-fit = phylolm(trait~pred,data=dat,phy=tre,model="lambda",measurement_error=TRUE)
+fit = phylolm(trait~pred,data=dat,phy=tre,model="lambda",measurement_error=TRUE,boot=100)
 summary(fit)
 
 }

--- a/man/transf.branch.lengths.Rd
+++ b/man/transf.branch.lengths.Rd
@@ -66,7 +66,7 @@ length added to tip \eqn{i} to make the tree ultrametric.
 \note{
 The default choice for the parameters are as follows: \code{alpha=0} for
 the selection strength in the OU model, \code{lambda=1}, \code{kappa=1},
-\code{delta=1}, \code{rate=0} for the EB model, \code{err_sigma2=0} for the variance of measurement errors. These default choices
+\code{delta=1}, \code{rate=0} for the EB model, \code{sigma2_error=0} for the variance of measurement errors. These default choices
 correspond to the BM model.
 
 Edges in the output tree are in pruningwise order.


### PR DESCRIPTION
Also, I added the description of model for measurement error in the manual. I disabled lambda plus measurement error, because there are identifiability problems. If you want to see for yourself, Below is an example. You would need to re-enable lambda + measurement error to run this example (comment out lines 12 and 13 in phylolm.R). The example shows that the likelihood profile is flat where it's maximum.

 first: simulate some data
```R
set.seed(1238)
tre = rcoal(60)
taxa = sort(tre$tip.label)
b0=0; b1=1;
x <- rTrait(n=1, phy=tre,model="EB",
            parameters=list(ancestral.state=0,sigma2=1))
response <- b0 + b1*x + 
  rTrait(n=1,phy=tre,model="BM",parameters=list(ancestral.state=0,sigma2=1))
dat = data.frame(trait=response[taxa],pred=x[taxa])
z <- response+rnorm(60,0,.4)
dat = data.frame(trait=z[taxa],pred=x[taxa])
```
next: use phylolm with a fixed lambda, to get the profile likelihood at many fixed lambda values
```R
lam = seq(0,1,by=.001)
loglk = rep(NA, length(lam))
s2e = rep(NA,length(lam))
cat("\n")
for ( i in 1:length(lam)){
  fit=phylolm(trait~pred,data=dat,phy=tre,model="lambda",measurement_error=TRUE,
                 lower.bound = lam[i], upper.bound = lam[i], starting.value = lam[i])
  loglk[i] = fit$logLik
  s2e[i] = fit$sigma2_error
  cat("done with replicate",i,"\r")
}
plot(loglk~lam, type="l") # full profile: lambda from 0 to 1
start=350 # next: zooming in the ML zone: flat.
plot(loglk[start:1001]~lam[start:1001], type="l")
```
the plot above showed the flat likelihood. The plot below shows how lambda hat varies with sigma_err hat:
```R
plot(lam[start:1001], s2e[start:1001], type="l") # 
```