### PR TITLE
Implement parallel bootstrap to lm (#10).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Authors@R: c(person("Lam Si Tung", "Ho", role=c("aut", "cre"), email="lamho86@gm
       person("Rachel", "Feldman",role="ctb"),
       person("Qing", "Yu",role="ctb"))
 Depends: R (>= 3.0), ape
+Imports: parallel
 Description: Provides functions for fitting phylogenetic linear models and phylogenetic generalized linear models. The computation uses an algorithm that is linear in the number of tips in the tree. The package also provides functions for simulating continuous or binary traits along the tree. Other tools include functions to test the adequacy of a population tree.
 License: GPL (>= 2) | file LICENSE
 URL: https://CRAN.R-project.org/package=phylolm

--- a/man/phylolm.Rd
+++ b/man/phylolm.Rd
@@ -9,7 +9,7 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
        "OUfixedRoot", "lambda", "kappa", "delta", "EB", "trend"),
        lower.bound = NULL, upper.bound = NULL,
        starting.value = NULL, measurement_error = FALSE,
-       boot=0,full.matrix = TRUE, ...)
+       boot=0,full.matrix = TRUE,parallel=NULL, ...)
 }
 
 \arguments{
@@ -24,6 +24,7 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
   \item{measurement_error}{a logical value indicating whether there is measurement error \code{sigma2_error} (see Details).}
   \item{boot}{number of independent bootstrap replicates, 0 means no bootstrap.}
   \item{full.matrix}{if \code{TRUE}, the full matrix of bootstrap estimates (coefficients and covariance parameters) will be returned.}
+  \item{parallel}{bootstrapping can be performed on a cluster by specifying the type of cluster (e.g. \code{"SOCK"})}
   \item{\dots}{further arguments to be passed to the function \code{optim}.}
 }
 \details{This function uses an algorithm that is linear in the number of


### PR DESCRIPTION
Following issue 10, I now finally had some time to implement this.

Can you please have a look whether you think this is worthwhile, and if you agree with the implementation? Specifically:

* Adding `parallel` as an `Import`.
* Use of the `parallel` parameter.

If you think this is useful, I can do the same for `phyloglm`.

It was mostly easy, using a function with `lapply` rather than a `for` loop. Additionally, `minus2llh` now takes a `y` values, since otherwise scoping rules dictate the use of the value of `y` at the point of creation of that function (during the normal model fitting).

Results between this and the original function remain the same:

```r
#create sample data for tests (based on example in ?phylolm)
set.seed(123456)
b0=0; b1=1;

tre_small = rcoal(50)
taxa_small = sort(tre_small$tip.label)
x_small <- rTrait(n=1, phy=tre_small,model="BM",
                  parameters=list(ancestral.state=0,sigma2=10))
y_small <- b0 + b1*x_small + 
  rTrait(n=1,phy=tre_small,model="lambda",parameters=list(
    ancestral.state=0,sigma2=1,lambda=0.5))
dat_small = data.frame(trait=y_small[taxa_small],pred=x_small[taxa_small])

tre_large = rcoal(500)
taxa_large = sort(tre_large$tip.label)
x_large <- rTrait(n=1, phy=tre_large,model="BM",
                  parameters=list(ancestral.state=0,sigma2=10))
y_large <- b0 + b1*x_large + 
  rTrait(n=1,phy=tre_large,model="lambda",parameters=list(
    ancestral.state=0,sigma2=1,lambda=0.5))
dat_large = data.frame(trait=y_large[taxa_large],pred=x_large[taxa_large])


## check results
library(dplyr)
library(tidyr)
library(ggplot2)
fit_old <- phylolm_current(trait~pred, data = dat_small, phy = tre_small, model = "lambda", boot = 1000)
fit_new <- phylolm(trait~pred, data = dat_small, phy = tre_small, model = "lambda", boot = 1000)
result <- bind_rows(old = as.data.frame(fit_old$bootstrap), new = as.data.frame(fit_new$bootstrap), 
                    .id = 'version')
ggplot(gather(result, 'parameter', 'value', -version), aes(version, value)) +
  geom_violin(draw_quantiles = c(0.25, 0.5, 0.75), fill = 1, alpha = 0.1) + 
  facet_wrap(~parameter, scales = 'free_y', nr = 1) +
  theme_minimal()
```

![result_comparsion](https://user-images.githubusercontent.com/15309336/37661008-0c30061c-2c54-11e8-9ead-fedf34b302db.png)

For larger bootstrap samples, and for larger trees in general, parallelization creates a significant performance benefit (as expected):

```r
library(microbenchmark)
mb <- microbenchmark(
  old_small_100 = phylolm_current(trait~pred,data=dat_small,phy=tre_small,model="lambda", boot = 100),
  new_small_100 = phylolm(trait~pred,data=dat_small,phy=tre_small,model="lambda", boot = 100),
  par_small_100 = phylolm(trait~pred,data=dat_small,phy=tre_small,model="lambda", boot = 100, parallel = "SOCK"),
  
  new_small_1000 = phylolm(trait~pred,data=dat_small,phy=tre_small,model="lambda", boot = 1000),
  par_small_1000 = phylolm(trait~pred,data=dat_small,phy=tre_small,model="lambda", boot = 1000, parallel = "SOCK"),
  
  new_small_10000 = phylolm(trait~pred,data=dat_small,phy=tre_small,model="lambda", boot = 10000),
  par_small_10000 = phylolm(trait~pred,data=dat_small,phy=tre_small,model="lambda", boot = 10000, parallel = "SOCK"),
  
  new_large_100 = phylolm(trait~pred,data=dat_large,phy=tre_large,model="lambda", boot = 100),
  par_large_100 = phylolm(trait~pred,data=dat_large,phy=tre_large,model="lambda", boot = 100, parallel = "SOCK"),
  
  new_large_1000 = phylolm(trait~pred,data=dat_large,phy=tre_large,model="lambda", boot = 1000),
  par_large_1000 = phylolm(trait~pred,data=dat_large,phy=tre_large,model="lambda", boot = 1000, parallel = "SOCK"),
  
  new_large_10000 = phylolm(trait~pred,data=dat_large,phy=tre_large,model="lambda", boot = 10000),
  par_large_10000 = phylolm(trait~pred,data=dat_large,phy=tre_large,model="lambda", boot = 10000, parallel = "SOCK"),
  times = 5
)
summary(mb) %>% 
  separate(expr, c('version', 'tree', 'boot_sample')) %>% 
  ggplot(aes(factor(boot_sample), median, ymin = min, ymax = max, color = version)) +
  geom_pointrange(position = position_dodge(0.3), size = 2/3) +
  geom_line(aes(group = version), position = position_dodge(0.3)) +
  scale_y_log10() +
  labs(title = 'runtime comparsion', x = 'size of bootstrap sample', color = 'code version',
       y = 'time (seconds)') +
  facet_wrap(~tree) +
  theme_minimal()
```
![runtime](https://user-images.githubusercontent.com/15309336/37661082-3f0bd156-2c54-11e8-8f68-a353f17ac75c.png)

`par` is the parallel runs (7 cores) and `new` is the non-parallel runs. Right panel is a small tree (50 species), left panel is a larger tree (500 species).

(I included a run of the old code, with the `for` loop to demonstrate that performance is the same as the no-parallel default of the new function.)
