### PR TITLE
Implement parallel bootstrap to glm (#10)

### DIFF
--- a/man/phyloglm.Rd
+++ b/man/phyloglm.Rd
@@ -10,7 +10,7 @@
 phyloglm(formula, data, phy, method = c("logistic_MPLE","logistic_IG10",
          "poisson_GEE"), btol = 10, log.alpha.bound = 4,
          start.beta=NULL, start.alpha=NULL,
-         boot = 0, full.matrix = TRUE)
+         boot = 0, full.matrix = TRUE, parallel = NULL)
 }
 
 \arguments{
@@ -25,6 +25,7 @@ phyloglm(formula, data, phy, method = c("logistic_MPLE","logistic_IG10",
   \item{start.alpha}{(logistic regression only) starting values for alpha (phylogenetic correlation).}
   \item{boot}{number of independent bootstrap replicates, \code{0} means no bootstrap.}
   \item{full.matrix}{if \code{TRUE}, the full matrix of bootstrap estimates (coefficients and alpha) will be returned.}
+  \item{parallel}{bootstrapping can be performed on a cluster by specifying the type of cluster (e.g. \code{"SOCK"})}
 }
 \details{
 This function uses an algorithm that is linear in the number of tips in the tree.


### PR DESCRIPTION
Following issue #10, and PR #11, here is the same parallel bootstrap implementation, but for `phyloglm`.

Results are the practically the same with the new and old function:

```
library(phylolm)
set.seed(123456)
tre = rtree(50)
x = rTrait(n=1,phy=tre)
X = cbind(rep(1,50),x)
y = rbinTrait(n=1,phy=tre, beta=c(-1,0.5), alpha=1 ,X=X)
dat = data.frame(trait01 = y, predictor = x)

fit_old_MPLE <- phyloglm_old(trait01~predictor,phy=tre,data=dat,boot=5000, method = 'logistic_MPLE')
fit_old_IG10 <- phyloglm_old(trait01~predictor,phy=tre,data=dat,boot=5000, method = 'logistic_IG10')
fit_new_MPLE <- phyloglm(trait01~predictor,phy=tre,data=dat,boot=5000, method = 'logistic_MPLE', parallel = "SOCK")
fit_new_IG10 <- phyloglm(trait01~predictor,phy=tre,data=dat,boot=5000, method = 'logistic_IG10', parallel = "SOCK")

library(dplyr)
library(tidyr)
library(ggplot2)
result <- bind_rows(old_MPLE = as.data.frame(fit_old_MPLE$bootstrap), 
                    new_MPLE = as.data.frame(fit_new_MPLE$bootstrap), 
                    old_IG10 = as.data.frame(fit_old_IG10$bootstrap), 
                    new_IG10 = as.data.frame(fit_new_IG10$bootstrap),
                    .id = 'version') %>% 
  mutate(version = factor(version, unique(version)))
ggplot(gather(result, 'parameter', 'value', -version), aes(version, value)) +
  geom_violin(draw_quantiles = c(0.25, 0.5, 0.75), fill = 1, alpha = 0.1) + 
  facet_wrap(~parameter, scales = 'free_y', nr = 1) +
  theme_minimal()
```

Let me know if you need anything else related to this!

![rplot](https://user-images.githubusercontent.com/15309336/37969206-735d3234-31d0-11e8-915d-3f171baba560.png)
