### PR TITLE
Add 'BugReports' and update 'URL'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Depends: R (>= 3.0), ape
 Imports: future.apply
 Description: Provides functions for fitting phylogenetic linear models and phylogenetic generalized linear models. The computation uses an algorithm that is linear in the number of tips in the tree. The package also provides functions for simulating continuous or binary traits along the tree. Other tools include functions to test the adequacy of a population tree.
 License: GPL (>= 2) | file LICENSE
-URL: https://CRAN.R-project.org/package=phylolm
+URL: https://github.com/lamho86/phylolm
+BugReports: https://github.com/lamho86/phylolm/issues
 Encoding: UTF-8
 Packaged: 2016-10-16
 NeedsCompilation: yes


### PR DESCRIPTION
To make it easier for users to find where to provide feedback:

Adding 'BugReports' to GitHub issue tracker.
Pointing 'URL' to GitHub page instead of CRAN page; I think this is the de-facto standard.  Not sure how common it is for CRAN packages to point the CRAN package page.