### PR TITLE
Minor issue when using my own transformed tree. 

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -204,7 +204,7 @@ three.point.compute <-
     diagWeight = rep(1,n)
     names(diagWeight) = phy$tip.label
   } else {
-    if (any(abs(diagWeight) <= .Machine$double.eps ^ 0.8))
+    if (any(abs(diagWeight) == 0))
       stop ("diagonal weights need to be non-zero.")
   }
   flag = 0


### PR DESCRIPTION
Dear Dr. Ho,

The input diagWeight was very low, but non-zero which meant it would be rejected based on this error check. However, if this error is bypassed with this minor change, the likelihoods match exactly what we find using typical inversion methods. 

Best,
James