### PR TITLE
Relax dependency on R >= 3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(person("Lam Si Tung", "Ho", role=c("aut", "cre"), email="lamho86@gm
       person("Wouter", "van der Bijl",role="ctb"),
       person("Joan", "Maspons",role="ctb"),
       person("Rutger", "Vos",role="ctb"))
-Depends: R (>= 4.0), ape
+Depends: R (>= 3.0), ape
 Imports: future.apply
 Description: Provides functions for fitting phylogenetic linear models and phylogenetic generalized linear models. The computation uses an algorithm that is linear in the number of tips in the tree. The package also provides functions for simulating continuous or binary traits along the tree. Other tools include functions to test the adequacy of a population tree.
 License: GPL (>= 2) | file LICENSE


### PR DESCRIPTION
Otherwise, it's not possible to install phylolm in quite recent R versions. Tests and check still ok.

Dependency added in commit 7b8226f1a7479159c468366da46502274c42d854 which seems unnecessary