### PR TITLE
Check that the response is univariate (vector or only one column).

### DIFF
--- a/R/phylolm.R
+++ b/R/phylolm.R
@@ -46,6 +46,12 @@ phylolm <- function(formula, data=list(), phy,
   y = model.response(mf)
   d = ncol(X)
 
+  ## Check that response is a vector
+  if (is.matrix(y) && ncol(y) > 1) {
+    stop(paste0("The response vector y in the formula is multivariate (it has several columns).\n",
+                "  Please fit each column one by one: 'phylolm' can only handle a simple (univariate) response vector y."))
+  }
+
   phy = reorder(phy,"pruningwise")
   n <- length(phy$tip.label)
   N <- dim(phy$edge)[1]

--- a/tests/testthat/testErrors.R
+++ b/tests/testthat/testErrors.R
@@ -1,0 +1,32 @@
+test_that("Multivariate Response throws an error", {
+  set.seed(12891026)
+  ## Tree
+  ntips <- 10
+  tree <- ape::rphylo(ntips, 0.1, 0)
+  ## multivariate data
+  ntraits <- 2
+  y_data <- phylolm::rTrait(ntraits, tree, model = "BM", parameters = list(sigma2 = 1))
+  ## Condition
+  cond <- sample(c(0, 1), ntips, replace = TRUE)
+  names(cond) <- tree$tip.label
+  y_data[cond == 1, ] <- y_data[cond == 1, ] + 5 ## strong effect
+  ## Data frame
+  all_dat <- data.frame(y = y_data, cond = cond)
+
+  ## Univariate fits (various specifications, all equal)
+  fit1 <- phylolm(y_data[, 1] ~ cond, phy = tree)
+  fit2 <- phylolm(y_data[, 1, drop = FALSE] ~ cond, phy = tree)
+  fit3 <- phylolm(y.1 ~ cond, phy = tree, data = all_dat)
+
+  expect_equal(fit1[!(names(fit1) %in% c("call", "formula"))],
+               fit2[!(names(fit1) %in% c("call", "formula"))])
+  expect_equal(fit1[!(names(fit1) %in% c("call", "formula"))],
+               fit3[!(names(fit1) %in% c("call", "formula"))])
+
+  ## Multivariate fits throw errors
+  expect_error(phylolm(y_data ~ cond, phy = tree),
+               "'phylolm' can only handle a simple \\(univariate\\) response vector y.")
+
+  expect_error(phylolm(cbind(y.1, y.2) ~ cond, phy = tree, data = all_dat),
+               "'phylolm' can only handle a simple \\(univariate\\) response vector y.")
+})


### PR DESCRIPTION
Hi,

As discussed earlier, I added an error when a matrix response is given to `phylolm`, instead of just a vector.

Current version would otherwise give an inconsistent result without throwing any warning.

Fitting each column independently as `lm` does could be interesting in the future, but might require more work.

Best,
Paul