### PR TITLE
Add a `confint` method for `phylolm` objects

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -11,7 +11,7 @@ importFrom("stats", "AIC", "add.scope", "binomial", "coef",
              "logLik", "model.frame", "model.matrix", "model.response",
              "optim", "pnorm", "poisson", "printCoefmat", "pt",
              "quantile", "reorder", "rnorm", "runif", "sd", "terms",
-             "var", "nobs")
+             "var", "nobs", "confint")
 importFrom("graphics", "hist", "mtext", "points")
 importFrom("stats", "chisq.test", "optimize", "pbeta")
 importFrom("utils", "flush.console")
@@ -40,3 +40,4 @@ S3method(summary, phyloglm)
 S3method(summary, phylolm)
 S3method(vcov, phyloglm)
 S3method(vcov, phylolm)
+S3method(confint, phylolm)

--- a/R/phylolm.R
+++ b/R/phylolm.R
@@ -612,3 +612,8 @@ plot.phylolm <-function(x, ...){
   plot(x$y, fitted(x), xlab = "Observed value", ylab = "Fitted value", ...)
 }
 ################################################
+################################################
+confint.phylolm <- function(object, parm, level = 0.95, ...){
+  object$df.residuals <- object$n - object$d
+  return(stats::confint.lm(object, parm, level, ...))
+}

--- a/man/phylolm-methods.Rd
+++ b/man/phylolm-methods.Rd
@@ -12,6 +12,7 @@
 \alias{extractAIC.phylolm}
 \alias{nobs.phylolm}
 \alias{plot.phylolm}
+\alias{confint.phylolm}
 
 \title{Methods for class 'phylolm'.}
 \description{These are method functions for class 'phylolm'.}
@@ -25,6 +26,7 @@
 \method{logLik}{phylolm}(object, ...)
 \method{AIC}{phylolm}(object, k=2, ...)
 \method{plot}{phylolm}(x, ...)
+\method{confint}{phylolm}(object, parm, level=0.95, ...)
 }
 
 \arguments{    
@@ -35,6 +37,8 @@
   \item{newdata}{an optional data frame to provide the predictor values
   at which predictions should be made. If omitted, the fitted values are used. Currently, predictions are made for new species whose placement in the tree is unknown. Only their covariate information is used. The prediction for the trend model is not currently implemented.}
   \item{k}{numeric, the penalty per parameter to be used; the default \code{k = 2} is the classical AIC.}
+  \item{parm}{a specification of which parameters are to be given confidence intervals, either a vector of numbers or a vector of names. If missing, all parameters are considered.}
+  \item{level}{the confidence level required.}
   \item{\dots}{further arguments to methods.}
 }
 

--- a/tests/testthat/testMethods.R
+++ b/tests/testthat/testMethods.R
@@ -1,0 +1,33 @@
+test_that("Test confint", {
+  set.seed(12891026)
+  ## Tree
+  ntips <- 10
+  tree <- ape::rphylo(ntips, 0.1, 0)
+  ## data
+  y_data <- phylolm::rTrait(1, tree, model = "BM", parameters = list(sigma2 = 1))
+  ## Condition
+  cond <- sample(c(0, 1), ntips, replace = TRUE)
+  names(cond) <- tree$tip.label
+  y_data[cond == 1] <- y_data[cond == 1] + 5 ## strong effect
+
+  ## Fit
+  fit <- phylolm(y_data ~ cond, phy = tree)
+
+  ## Confidence Interval
+  level <- 0.95
+  ci <- confint(fit, level = level)
+
+  ## Confidence Interval - Manual
+  quants <- c((1 - level) / 2, 1 - (1 - level) / 2)
+  ci_manual <- coef(fit) + summary(fit)$coefficients[, 2] %o% qt(quants, fit$n - fit$d)
+
+  ## Equal
+  expect_equivalent(ci, ci_manual)
+
+  ## One parameter at a time, changing level
+  level <- 0.90
+  ci <- confint(fit, parm = "cond", level = level)
+  quants <- c((1 - level) / 2, 1 - (1 - level) / 2)
+  ci_manual <- coef(fit)[2] + summary(fit)$coefficients[2, 2] * qt(quants, fit$n - fit$d)
+  expect_equivalent(ci, ci_manual)
+})


### PR DESCRIPTION
Hi,

Currently, `confint` applied to a `phylolm` object does not throw any warning, but falls back to `confint.default`, which uses the quantiles of the Gaussian distribution.

With the proposed change, `confint` would call `confint.lm`, and gives the (broader) intervals obtained from a Student distribution with n-d degrees of freedom.

See the added tests for an example.

I added a line in the doc and NAMESPACE, checks pass locally, but I hope I did not forget anything while defining the method ?

Thanks,
Paul