### PR TITLE
added arguement check.precision in three.point.compute

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -185,7 +185,7 @@ transf.branch.lengths <-
 
 three.point.compute <-
   function(phy, P, Q = NULL, diagWeight = NULL, 
-           check.pruningwise = TRUE, check.names = TRUE) 
+           check.pruningwise = TRUE, check.names = TRUE, check.precision = TRUE) 
 {
   ## For an extra tip Variance, like diagonal measurement error E:
   ## V = DVoD + E = D Vn D with Vn = Vo + D^{-1}ED^{-1} still from tree.
@@ -204,7 +204,7 @@ three.point.compute <-
     diagWeight = rep(1,n)
     names(diagWeight) = phy$tip.label
   } else {
-    if (any(abs(diagWeight) <= .Machine$double.eps ^ 0.8))
+    if (any(abs(diagWeight) <= .Machine$double.eps ^ 0.8) & check.precision)
       stop ("diagonal weights need to be non-zero.")
   }
   flag = 0

--- a/man/three.point.compute.Rd
+++ b/man/three.point.compute.Rd
@@ -6,7 +6,7 @@
     V)} of a (generalized) three-point structured matrix.}
 \usage{
 three.point.compute(phy, P, Q = NULL, diagWeight = NULL, 
-            check.pruningwise = TRUE, check.names = TRUE)
+            check.pruningwise = TRUE, check.names = TRUE, check.precision = TRUE)
 }
 \arguments{
   \item{phy}{a rooted phylogenetic tree of type phylo with branch
@@ -20,6 +20,7 @@ three.point.compute(phy, P, Q = NULL, diagWeight = NULL,
   \item{check.names}{if FALSE, the row names of \code{P}, \code{Q}, and
     the names of \code{diagWeight} are assumed to be the same as the
     labels of the tips in the tree.} 
+  \item{check.precision}{if FALSE, diagWeight will be allowed to be below Machine epsilon. Recommended to remain TRUE.} 
 }
 \value{
 	\item{vec11}{\eqn{1'V^{-1}1}.}
@@ -31,7 +32,7 @@ three.point.compute(phy, P, Q = NULL, diagWeight = NULL,
 	\item{logd}{\eqn{\log(\det V)}{log(det V)}.}
 }
 \references{
-Ho, L. S. T. and Ané, C. (2014). "A linear-time algorithm for Gaussian and
+Ho, L. S. T. and An?, C. (2014). "A linear-time algorithm for Gaussian and
 non-Gaussian trait evolution models". Systematic Biology \bold{63}(3):397-408.
 }
 \author{Lam Si Tung Ho, Robert Lachlan}


### PR DESCRIPTION
allows users to ignore the check comparing diagWeight to Machine epsilon. 