### PR TITLE
Fitting models with REML.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ BugReports: https://github.com/lamho86/phylolm/issues
 Encoding: UTF-8
 Packaged: 2016-10-16
 NeedsCompilation: yes
-Suggests: testthat
+Suggests: testthat, nlme

--- a/R/phylolm.R
+++ b/R/phylolm.R
@@ -1,23 +1,23 @@
-phylolm <- function(formula, data=list(), phy, 
+phylolm <- function(formula, data=list(), phy,
 	model=c("BM","OUrandomRoot","OUfixedRoot","lambda","kappa","delta","EB","trend"),
 	lower.bound=NULL, upper.bound=NULL, starting.value=NULL, measurement_error = FALSE,
-	boot=0,full.matrix = TRUE, save = FALSE, ...)
+	boot=0,full.matrix = TRUE, save = FALSE, REML = FALSE, ...)
 {
 
-  ## initialize	
+  ## initialize
   if (!inherits(phy, "phylo")) stop("object \"phy\" is not of class \"phylo\".")
-  model = match.arg(model)	
+  model = match.arg(model)
   if ((model=="trend")&(is.ultrametric(phy)))
    stop("the trend is unidentifiable for ultrametric trees.")
   if ((model=="lambda") && measurement_error)
     stop("the lambda transformation and measurement error cannot be used together: they are not distinguishable")
   if (is.null(phy$edge.length)) stop("the tree has no branch lengths.")
-  if (is.null(phy$tip.label)) stop("the tree has no tip labels.")	
-  tol = 1e-10	
+  if (is.null(phy$tip.label)) stop("the tree has no tip labels.")
+  tol = 1e-10
 
   mf = model.frame(formula=formula,data=data)
-  
-  
+
+
   if (is.null(rownames(mf))) {
    if (nrow(mf)!=length(phy$tip.label))
       stop("number of rows in the data does not match the number of tips in the tree.")
@@ -78,7 +78,7 @@ phylolm <- function(formula, data=list(), phy,
       Tmax = Tmax + min(D)
     }
   }
-	
+
   ## preparing for trend model
   if (model == "trend") {
     trend = pruningwise.distFromRoot(phy)[1:n]
@@ -97,7 +97,7 @@ phylolm <- function(formula, data=list(), phy,
   colnames(bounds.default) = c("min","max")
 
   ## Default starting values
-  starting.values.default = c(0.5/Tmax,0.5,0.5,0.5,-1/Tmax,1) 
+  starting.values.default = c(0.5/Tmax,0.5,0.5,0.5,-1/Tmax,1)
   names(starting.values.default) = c("alpha","lambda","kappa","delta","rate","sigma2_error")
 
   ## Utility functions to get values
@@ -173,11 +173,18 @@ phylolm <- function(formula, data=list(), phy,
         result=double(ole))$result[4]
       sigma2hat = tmpyy/n
     }
-    n2llh = as.numeric( n*log(2*pi) + n + n*log(sigma2hat) + comp$logd) # -2 log-likelihood
+    vcov = sigma2hat*invXX*n/(n-d)
+    if (!REML) {
+      n2llh = as.numeric( n*log(2*pi) + n + n*log(sigma2hat) + comp$logd) # -2 log-likelihood
+    } else {
+      sigma2hat <- sigma2hat * n / (n-d)
+      # log|X'V^{-1}X|
+      ldXX <- determinant(comp$XX, logarithm = TRUE)$modulus
+      n2llh <- as.numeric( (n - d) * (log(2*pi) + 1 + log(sigma2hat)) + comp$logd + ldXX) # -2 restricted log-likelihood
+    }
     if (flag)
       n2llh = n2llh + parameters$alpha * 2*sum(D)
     ## because diag matrix used for generalized 3-point structure is exp(alpha diag(D))
-    vcov = sigma2hat*invXX*n/(n-d)
     return(list(n2llh=n2llh, betahat = as.vector(betahat), sigma2hat=sigma2hat,vcov=vcov))
   }
 
@@ -274,7 +281,7 @@ phylolm <- function(formula, data=list(), phy,
         if ((model == "EB")&&(prm[[1]] == 0)) matchbound <- NULL
       }
       # error
-      if (length(lower) > 1 
+      if (length(lower) > 1
           && (isTRUE(all.equal(prm[[2]], lower[2], tol=tol))
               || isTRUE(all.equal(prm[[2]], upper[2],tol=tol)))) {
         matchbound <- c(matchbound, 2)
@@ -324,6 +331,7 @@ phylolm <- function(formula, data=list(), phy,
   results$call = match.call()
   results$model = model
   results$boot = boot
+  results$REML = REML
 
   ## starting the bootstrap
   if (boot>0) {
@@ -373,13 +381,13 @@ phylolm <- function(formula, data=list(), phy,
     if (!(model %in% c("BM","trend"))) {
       names(bootvector)[colnumberalpha] <- names(prm)[1]
     }
-    
+
     # define a function that will calculate the boot statistics. It is only dependent on `y`
     boot_model <- function(y) {
       # all other cases: first get 'prm' up-to-date.
       if (!(model %in% c("BM","trend")) && lower[1]==upper[1])
         bootvector[colnumberalpha] = lower[1] # will be used later to update 'prm'
-      
+
       # otherwise: something needs to be optimized: m.e., alpha, or both.
       # below: storing 'standardized' estimated of m.e. variance in MLEsigma2_error. Rescaled later.
       if (!(model %in% c("BM","trend")) && lower[1] != upper[1]){
@@ -409,7 +417,7 @@ phylolm <- function(formula, data=list(), phy,
           prm[[1]] = MLEsigma2_error
         }
       }
-      
+
       BMest = loglik(prm, y, X)
       if (model %in% OU)
         BMest$sigma2hat = 2*prm[[1]] * BMest$sigma2hat # was "gamma" originally: sigma2 = 2 alpha gamma
@@ -419,10 +427,10 @@ phylolm <- function(formula, data=list(), phy,
       bootvector[ncoeff+1] <- BMest$sigma2hat
       return(bootvector)
     }
-    
+
     bootmatrix <- future.apply::future_lapply(as.data.frame(booty), boot_model)
     bootmatrix <- do.call(rbind, bootmatrix)
-    
+
     # summarize bootstrap estimates
     ind.na <- which(is.na(bootmatrix[,1]))
     # indices of replicates that failed: phylolm had an error
@@ -451,23 +459,23 @@ phylolm <- function(formula, data=list(), phy,
     ### Turn on warnings
     options(warn=0)
   }
-  
+
   ## R squared
   if (model %in% OU) {
     RMS <- results$sigma2 / 2/results$optpar * n/(n-d)
     RSSQ <- results$sigma2 / 2/results$optpar * n
-    
+
   } else {
     RMS <- results$sigma2 * n/(n-d)
     RSSQ <- results$sigma2 * n
   }
-  
+
   xdummy <- matrix(rep(1, length(y)))
   # local variables used in loglik function
   d <- ncol(xdummy)
   ole <- 4 + 2*d + d*d # output length
   nullMod <- loglik(prm, y, xdummy)
-  
+
   NMS <- nullMod$sigma2hat * n/(n-1)
   NSSQ <- nullMod$sigma2hat * n
 
@@ -557,10 +565,10 @@ print.summary.phylolm <- function(x, digits = max(3, getOption("digits") - 3), .
 
   cat("\nCoefficients:\n")
   printCoefmat(x$coefficients, P.values=TRUE, has.Pvalue=TRUE)
-  
+
   cat("\nR-squared:", formatC(x$r.squared, digits = digits))
   cat("\tAdjusted R-squared:", formatC(x$adj.r.squared, digits = digits), "\n")
-  
+
   if (!is.null(x$optpar)) {
     cat("\nNote: p-values and R-squared are conditional on ")
     if (x$model %in% c("OUrandomRoot","OUfixedRoot")) cat("alpha=",x$optpar,".",sep="")
@@ -589,7 +597,7 @@ print.summary.phylolm <- function(x, digits = max(3, getOption("digits") - 3), .
 ################################################
 residuals.phylolm <-function(object,type=c("response"), ...){
   type <- match.arg(type)
-  object$residuals	 
+  object$residuals
 }
 ################################################
 vcov.phylolm <- function(object, ...){
@@ -621,7 +629,7 @@ predict.phylolm <- function(object, newdata=NULL, ...){
   if (object$model=="trend")
     stop("Predicting for trend model has not been implemented.")
   if(is.null(newdata)) y <- fitted(object)
-  else{			
+  else{
     X = model.matrix(delete.response(terms(formula(object))),data = newdata)
     y <- X %*% coef(object)
   }

--- a/man/phylolm.Rd
+++ b/man/phylolm.Rd
@@ -9,7 +9,7 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
        "OUfixedRoot", "lambda", "kappa", "delta", "EB", "trend"),
        lower.bound = NULL, upper.bound = NULL,
        starting.value = NULL, measurement_error = FALSE,
-       boot=0,full.matrix = TRUE, save = FALSE, ...)
+       boot=0,full.matrix = TRUE, save = FALSE, REML = FALSE, ...)
 }
 
 \arguments{
@@ -25,6 +25,7 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
   \item{boot}{number of independent bootstrap replicates, 0 means no bootstrap.}
   \item{full.matrix}{if \code{TRUE}, the full matrix of bootstrap estimates (coefficients and covariance parameters) will be returned.}
   \item{save}{if \code{TRUE}, the simulated bootstrap data will be returned.}
+  \item{REML}{Use ML (default) or REML for estimating the parameters.}
   \item{\dots}{further arguments to be passed to the function \code{optim}.}
 }
 \details{This function uses an algorithm that is linear in the number of
@@ -47,16 +48,16 @@ phylolm(formula, data = list(), phy, model = c("BM", "OUrandomRoot",
   sampling error on the species mean, etc.).
 
   By default, the bounds on the phylogenetic parameters are
-  \eqn{[10^{-7}/T,50/T]} for \eqn{\alpha}{alpha}, 
+  \eqn{[10^{-7}/T,50/T]} for \eqn{\alpha}{alpha},
   \eqn{[10^{-7},1]} for \eqn{\lambda}{lambda},
   \eqn{[10^{-6},1]} for \eqn{\kappa}{kappa},
   \eqn{[10^{-5},3]} for \eqn{\delta}{delta} and
   \eqn{[-3/T,0]} for \code{rate}, where \eqn{T} is the mean root-to-tip distance.
   \eqn{[10^{-16}, 10^{16}]} for the ratio \code{sigma2_error}/\code{sigma2} (if measurement errors is used).
-  
-  Bootstrapping can be parallelized using the \code{future} package on any future 
-  compatible back-end. For example, run \code{library(future); plan(multiprocess))}, 
-  after which bootstrapping will automatically occur in parallel. See 
+
+  Bootstrapping can be parallelized using the \code{future} package on any future
+  compatible back-end. For example, run \code{library(future); plan(multiprocess))},
+  after which bootstrapping will automatically occur in parallel. See
   \code{\link[future]{plan}} for options.
 }
 \value{
@@ -148,7 +149,7 @@ taxa = sort(tre$tip.label)
 b0=0; b1=1;
 x <- rTrait(n=1, phy=tre,model="BM",
             parameters=list(ancestral.state=0,sigma2=10))
-y <- b0 + b1*x + 
+y <- b0 + b1*x +
      rTrait(n=1,phy=tre,model="lambda",parameters=list(
               ancestral.state=0,sigma2=1,lambda=0.5))
 dat = data.frame(trait=y[taxa],pred=x[taxa])

--- a/tests/testthat/testREML.R
+++ b/tests/testthat/testREML.R
@@ -1,0 +1,122 @@
+test_that("REML estimates", {
+  skip_if_not_installed("nlme")
+
+  ## Taken from example
+  set.seed(123456)
+  tre = rphylo(60, 0.1, 0.01)
+  tre_h <- max(vcv(tre))
+  taxa = sort(tre$tip.label)
+  b0 = 0; b1 = 1; b2 = -2;
+  x <- rTrait(n = 1, phy = tre, model = "BM",
+              parameters = list(ancestral.state = 0, sigma2 = 10))
+  f <- sample(c(0, 1), length(taxa), replace = TRUE)
+  names(f) <- names(x)
+  y <- b0 + b1*x + b2 * f +
+    rTrait(n = 1, phy = tre, model = "lambda",
+           parameters = list(
+             ancestral.state = 0, sigma2 = 1, lambda = 0.5))
+  # adding measurement errors
+  z <- y + rnorm(length(taxa), 0, 1)
+  dat = data.frame(trait = z[taxa], pred = x[taxa], fac = as.factor(f[taxa]), species = taxa)
+
+  ## Fit - BM - ML
+  fit = phylolm(trait ~ pred + fac, data = dat, phy = tre, model = "BM")
+  fit_gls <- nlme::gls(trait ~ pred + fac, data = dat, correlation = corBrownian(1, tre, form = ~species), method = "ML")
+
+  expect_equal(fit$logLik, fit_gls$logLik)
+  expect_equal(fit$coefficients, fit_gls$coefficients)
+  expect_equal(fit$vcov, fit_gls$varBeta)
+  expect_equal(fit$n, fit_gls$dims$N)
+  expect_equal(fit$d, fit_gls$dims$p)
+  expect_equal(summary(fit)$coefficients[, "t.value"], summary(fit_gls)$tTable[, "t-value"])
+  expect_equal(fit$fitted[taxa], fit_gls$fitted[taxa])
+  expect_equal(fit$residuals[taxa], fit_gls$residuals[taxa])
+  expect_equal(AIC(fit), AIC(fit_gls))
+  expect_equal(logLik(fit)$logLik, logLik(fit_gls)[1])
+  expect_equal(fit$sigma2, fit_gls$sigma^2 / tre_h)
+
+  ## Fit - BM - REML
+  fit = phylolm(trait ~ pred, data = dat, phy = tre, model = "BM", REML = TRUE)
+  fit_gls <- nlme::gls(trait ~ pred, data = dat, correlation = corBrownian(1, tre, form = ~species), method = "REML")
+
+  expect_equal(fit$logLik, fit_gls$logLik)
+  expect_equal(fit$coefficients, fit_gls$coefficients)
+  expect_equal(fit$vcov, fit_gls$varBeta)
+  expect_equal(fit$n, fit_gls$dims$N)
+  expect_equal(fit$d, fit_gls$dims$p)
+  expect_equal(summary(fit)$coefficients[, "t.value"], summary(fit_gls)$tTable[, "t-value"])
+  expect_equal(fit$fitted[taxa], fit_gls$fitted[taxa])
+  expect_equal(fit$residuals[taxa], fit_gls$residuals[taxa])
+  expect_equal(AIC(fit), AIC(fit_gls))
+  expect_equal(logLik(fit)$logLik, logLik(fit_gls)[1])
+  expect_equal(fit$sigma2, fit_gls$sigma^2 / tre_h)
+
+  ## Fit - lambda - ML
+  fit = phylolm(trait ~ pred + fac, data = dat, phy = tre, model = "lambda")
+  fit_gls <- nlme::gls(trait ~ pred + fac, data = dat, correlation = corPagel(1, tre, form = ~species), method = "ML")
+
+  expect_equal(fit$logLik, fit_gls$logLik)
+  expect_equal(fit$coefficients, fit_gls$coefficients, tolerance = 1e-5)
+  expect_equal(fit$vcov, fit_gls$varBeta, tolerance = 1e-5)
+  expect_equal(fit$n, fit_gls$dims$N)
+  expect_equal(fit$d, fit_gls$dims$p)
+  expect_equal(summary(fit)$coefficients[, "t.value"], summary(fit_gls)$tTable[, "t-value"], tolerance = 1e-5)
+  expect_equal(fit$fitted[taxa], fit_gls$fitted[taxa], tolerance = 1e-5)
+  expect_equal(fit$residuals[taxa], fit_gls$residuals[taxa], tolerance = 1e-5)
+  expect_equal(AIC(fit), AIC(fit_gls))
+  expect_equal(logLik(fit)$logLik, logLik(fit_gls)[1])
+  expect_equal(fit$optpar, fit_gls$modelStruct$corStruct[1], tolerance = 1e-5)
+  expect_equal(fit$sigma2, fit_gls$sigma^2 / tre_h, tolerance = 1e-5)
+
+  ## Fit - lambda - REML
+  fit = phylolm(trait ~ pred, data = dat, phy = tre, model = "lambda", REML = TRUE)
+  fit_gls <- nlme::gls(trait ~ pred, data = dat, correlation = corPagel(1, tre, form = ~species), method = "REML")
+
+  expect_equal(fit$logLik, fit_gls$logLik)
+  expect_equal(fit$coefficients, fit_gls$coefficients, tolerance = 1e-6)
+  expect_equal(fit$vcov, fit_gls$varBeta, tolerance = 1e-6)
+  expect_equal(fit$n, fit_gls$dims$N)
+  expect_equal(fit$d, fit_gls$dims$p)
+  expect_equal(summary(fit)$coefficients[, "t.value"], summary(fit_gls)$tTable[, "t-value"], tolerance = 1e-6)
+  expect_equal(fit$fitted[taxa], fit_gls$fitted[taxa], tolerance = 1e-6)
+  expect_equal(fit$residuals[taxa], fit_gls$residuals[taxa], tolerance = 1e-6)
+  expect_equal(AIC(fit), AIC(fit_gls))
+  expect_equal(logLik(fit)$logLik, logLik(fit_gls)[1])
+  expect_equal(fit$optpar, fit_gls$modelStruct$corStruct[1], tolerance = 1e-6)
+  expect_equal(fit$sigma2, fit_gls$sigma^2 / tre_h, tolerance = 1e-6)
+
+  ## Fit - OU - ML
+  fit = phylolm(trait ~ pred + fac, data = dat, phy = tre, model = "OUrandomRoot")
+  fit_gls <- nlme::gls(trait ~ pred + fac, data = dat, correlation = corMartins(0.1, tre, form = ~species), method = "ML")
+
+  expect_equal(fit$logLik, fit_gls$logLik)
+  expect_equal(fit$coefficients, fit_gls$coefficients, tolerance = 1e-6)
+  expect_equal(fit$vcov, fit_gls$varBeta, tolerance = 1e-6)
+  expect_equal(fit$n, fit_gls$dims$N)
+  expect_equal(fit$d, fit_gls$dims$p)
+  expect_equal(summary(fit)$coefficients[, "t.value"], summary(fit_gls)$tTable[, "t-value"], tolerance = 1e-5)
+  expect_equal(fit$fitted[taxa], fit_gls$fitted[taxa], tolerance = 1e-6)
+  expect_equal(fit$residuals[taxa], fit_gls$residuals[taxa], tolerance = 1e-6)
+  expect_equal(AIC(fit), AIC(fit_gls))
+  expect_equal(logLik(fit)$logLik, logLik(fit_gls)[1])
+  expect_equal(fit$optpar, fit_gls$modelStruct$corStruct[1], tolerance = 1e-6)
+  expect_equal(fit$sigma2 / 2 / fit$optpar, fit_gls$sigma^2, tolerance = 1e-6)
+
+  ## Fit - OU - REML
+  fit = phylolm(trait ~ pred, data = dat, phy = tre, model = "OUrandomRoot", REML = TRUE)
+  fit_gls <- nlme::gls(trait ~ pred, data = dat, correlation = corMartins(0.1, tre, form = ~species), method = "REML")
+
+  expect_equal(fit$logLik, fit_gls$logLik)
+  expect_equal(fit$coefficients, fit_gls$coefficients, tolerance = 1e-6)
+  expect_equal(fit$vcov, fit_gls$varBeta, tolerance = 1e-6)
+  expect_equal(fit$n, fit_gls$dims$N)
+  expect_equal(fit$d, fit_gls$dims$p)
+  expect_equal(summary(fit)$coefficients[, "t.value"], summary(fit_gls)$tTable[, "t-value"], tolerance = 1e-5)
+  expect_equal(fit$fitted[taxa], fit_gls$fitted[taxa], tolerance = 1e-6)
+  expect_equal(fit$residuals[taxa], fit_gls$residuals[taxa], tolerance = 1e-6)
+  expect_equal(AIC(fit), AIC(fit_gls))
+  expect_equal(logLik(fit)$logLik, logLik(fit_gls)[1])
+  expect_equal(fit$optpar, fit_gls$modelStruct$corStruct[1], tolerance = 1e-6)
+  expect_equal(fit$sigma2 / 2 / fit$optpar, fit_gls$sigma^2, tolerance = 1e-6)
+
+})


### PR DESCRIPTION
This is a first attempt to add an REML option to the `phylolm` fit.
I implemented this because I needed it in a project, and I figured I might share it with you.
But maybe it does not fit within your development plan, and you'd prefer to stay with the curent "ML only" implementation?
No problem if that is the case, just let me know.

Changes: 
* definition of the internal `logLik` function changes when REML is `TRUE`.
* `vcov` is changed accordingly : even in the ML case, the REML estimate of `sigma2` is taken (as was previously).
* tests of the REML and ML estimate against the `gls` function, for BM, lambda and OU models.

Questions:
* Is there anything to change elsewhere ? E.g. in the bootstrap code, or in other functions ?
* Would there be some more tests to add ? E.g. against other implementations, such as `Rphylopars` or `mvMORPH` ?
* Are there cases when this REML implementation would fail ? E.g. for non ultrametric trees ?

Thank you !
